### PR TITLE
Added Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.11.4 as builder
+WORKDIR /go/src/github.com/leominov/redis_sentinel_exporter
+COPY . .
+RUN make
+
+
+FROM scratch
+COPY --from=builder /go/src/github.com/leominov/redis_sentinel_exporter/redis_sentinel_exporter /go/bin/redis_sentinel_exporter
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+ENTRYPOINT ["/go/bin/redis_sentinel_exporter"]  


### PR DESCRIPTION
As Makefile has the docker instruction to build docker image, we should
have the correspondent Dockerfile to build it.

Building it on golang container and copying the binary to a scratch
image